### PR TITLE
LeetCode のコンテスト情報を追加

### DIFF
--- a/contestsite.py
+++ b/contestsite.py
@@ -104,3 +104,15 @@ class yukicoder(ContestSite):
     
     def get_contestdata(self):
         return googlecalutil.get_contestdata(self.siteinfo)
+
+
+class LeetCode(ContestSite):
+    def __init__(self):
+        super().__init__(
+            "LeetCode",
+            "LC",
+            "tlvovsip3t3045rnkq0rt7d77c@group.calendar.google.com"
+        )
+
+    def get_contestdata(self):
+        return googlecalutil.get_contestdata(self.siteinfo)

--- a/script.py
+++ b/script.py
@@ -1,7 +1,7 @@
 import datetime
 import pytz
 import dtwrapper
-from contestsite import AtCoder, TopCoder, Codeforces, CSAcademy, yukicoder
+from contestsite import AtCoder, TopCoder, Codeforces, CSAcademy, yukicoder, LeetCode
 import twitterutil
 
 
@@ -13,7 +13,8 @@ def lambda_handler(event, context):
                      TopCoder(),
                      Codeforces(),
                      CSAcademy(),
-                     yukicoder())
+                     yukicoder(),
+                     LeetCode())
     contests = []
     for site in contest_sites:
         contests.extend(site.get_contestdata())


### PR DESCRIPTION
LeetCode ( https://leetcode.com/ ) のコンテスト情報を追加しました。

LeetCode は 毎週1回コンテスト (*1) を開いており、難易度は AtCoder 水色 - 青の人なら全完できるレベルです。私も毎週出来る限り join していることから、競プロリマインダー でも見られると便利だと考えました。

尚、コンテストの Google Calendar 情報は https://clist.by/resource/leetcode.com/ から取得しており、ここは自動で更新される情報とのことです。

(*1) https://leetcode.com/contest/
