### PR TITLE
AtCoderのスクレイピングを修正する

### DIFF
--- a/src/contestsite.py
+++ b/src/contestsite.py
@@ -34,20 +34,21 @@ class AtCoder(ContestSite):
         )
 
     def get_contestdata(self):
-        html = urlopen("https://beta.atcoder.jp/contests/")
+        html = urlopen("https://atcoder.jp/contests/")
         bs_obj = BeautifulSoup(html, "html.parser")
         table = bs_obj.find_all("table", class_="table table-default table-striped table-hover table-condensed table-bordered small")[1]
         rows = table.find_all("tr")
+
         del rows[0]
 
         contests = []
         for row in rows:
-            contest_data = [start, contestname, duration, rated]
-            contest_data = [cell.get_text() for cell in row.find_all("td")]
+            # contest_data = [start, contestname, duration, rated]
+            contest_data = row.find_all("td")
 
-            contest_name = contest_data[1]
-            contest_begin = parse(contest_data[0]).astimezone(pytz.timezone('Asia/Tokyo'))
-            contest_duration = dtwrapper.str2timedelta(contest_data[2])
+            contest_name = contest_data[1].find("a").get_text()
+            contest_begin = parse(contest_data[0].get_text()).astimezone(pytz.timezone('Asia/Tokyo'))
+            contest_duration = dtwrapper.str2timedelta(contest_data[2].get_text())
             contest = ContestData(contest_name,
                                   self.siteinfo,
                                   contest_begin,

--- a/src/contestsite.py
+++ b/src/contestsite.py
@@ -30,35 +30,32 @@ class AtCoder(ContestSite):
         super().__init__(
             "AtCoder",
             "AC",
-            "atcoder.jp_gqd1dqpjbld3mhfm4q07e4rops@group.calendar.google.com"
+            "" # atcoder.jp_gqd1dqpjbld3mhfm4q07e4rops@group.calendar.google.com
         )
 
     def get_contestdata(self):
-        return googlecalutil.get_contestdata(self.siteinfo)
+        html = urlopen("https://beta.atcoder.jp/contests/")
+        bs_obj = BeautifulSoup(html, "html.parser")
+        table = bs_obj.find_all("table", class_="table table-default table-striped table-hover table-condensed table-bordered small")[1]
+        rows = table.find_all("tr")
+        del rows[0]
 
-        # ===== スクレイピングこわれてる =====
-        # html = urlopen("https://beta.atcoder.jp/contests/")
-        # bs_obj = BeautifulSoup(html, "html.parser")
-        # table = bs_obj.find_all("table", class_="table table-default table-striped table-hover table-condensed table-bordered small")[1]
-        # rows = table.find_all("tr")
-        # del rows[0]
+        contests = []
+        for row in rows:
+            contest_data = [start, contestname, duration, rated]
+            contest_data = [cell.get_text() for cell in row.find_all("td")]
 
-        # contests = []
-        # for row in rows:
-        #     # contest_data = [start, contestname, duration, rated]
-        #     contest_data = [cell.get_text() for cell in row.find_all("td")]
-
-        #     contest_name = contest_data[1]
-        #     contest_begin = parse(contest_data[0]).astimezone(pytz.timezone('Asia/Tokyo'))
-        #     contest_duration = dtwrapper.str2timedelta(contest_data[2])
-        #     contest = ContestData(contest_name,
-        #                           self.siteinfo,
-        #                           contest_begin,
-        #                           contest_duration)
-        #     if(not contest.is_valid(dtwrapper.now())):
-        #         continue
-        #     contests.append(contest)
-        # return contests
+            contest_name = contest_data[1]
+            contest_begin = parse(contest_data[0]).astimezone(pytz.timezone('Asia/Tokyo'))
+            contest_duration = dtwrapper.str2timedelta(contest_data[2])
+            contest = ContestData(contest_name,
+                                  self.siteinfo,
+                                  contest_begin,
+                                  contest_duration)
+            if(not contest.is_valid(dtwrapper.now())):
+                continue
+            contests.append(contest)
+        return contests
 
 
 class TopCoder(ContestSite):


### PR DESCRIPTION
AtCoderのGoogleカレンダー（ atcoder.jp_gqd1dqpjbld3mhfm4q07e4rops@group.calendar.google.com ）が公式から消滅していた（と思われる）ため、スクレイピングを利用するように戻してみました。

単にスクレイピングのコードのコメントアウトを戻すだけで概ね動作しました。
その上で、AtCoderのコンテスト名の先頭の◉の影響で、変な改行が以下のように入っていたので、そこだけ修正しました。
```
[(
◉
AtCoder Grand Contest 045
, AtCoder, 2020-06-07 21:00:00+09:00, 1:50:00)]
```
↓
```
[(AtCoder Grand Contest 044, AtCoder, 2020-05-23 21:00:00+09:00, 2:30:00)]
```

ただ、過去に`===== スクレイピングこわれてる =====`と書かれた経緯を把握していないため、想定の動作と異なっていればすみません。